### PR TITLE
I've updated the Vite build configuration to output to 'docs' for Git…

### DIFF
--- a/project/vite.config.ts
+++ b/project/vite.config.ts
@@ -5,7 +5,7 @@ import react from '@vitejs/plugin-react';
 export default defineConfig({
   base: "/<REPO_NAME>/", // User will replace <REPO_NAME>
   build: {
-    outDir: "dist",
+    outDir: "docs",
   },
   plugins: [react()],
   optimizeDeps: {


### PR DESCRIPTION
…Hub Pages.

This change modifies `project/vite.config.ts` to change the build output directory from `dist` to `docs`.

This adjustment will help you deploy the Vite application to GitHub Pages by building the site into the `project/docs/` directory. This allows you to configure GitHub Pages to serve from the `/docs` folder on the `main` branch, which is a common and cleaner pattern than deploying build artifacts to the repository root.

You should configure the `base` path to match your repository name (e.g., `"/<repo-name>/"`).